### PR TITLE
Add setup.cfg for package installation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@ or more lines of text.
 ## Basic Usage
 
 The `toolbox` module is meant to be used as a library, not a script, so
-you'll need to first make sure it's findable by Python. Either copy
-`toolbox.py` to your project directory, or adjust `PYTHONPATH`:
+you'll need to first make sure it's findable by Python. Either
+
+1. copy `toolbox.py` to your project directory
+2. adjust `PYTHONPATH`
 
 ```bash
 export PYTHONPATH=/path/to/toolbox:"$PYTHONPATH"
+```
+
+3. or install via pip
+
+```bash
+pip install toolbox/
 ```
 
 You can then load it in Python and use it to read stored Toolbox files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+  "setuptools>=42",
+  "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = toolbox
+version = 0.0.1
+author = Michael Wayne Goodman
+description = Python implementation of SILs Toolbox Standard Format Markers (SFM) format.
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/goodmami/toolbox
+classifiers =
+    Programming Language :: Python :: 3
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = find:


### PR DESCRIPTION
I added some very barebones `setup.cfg` and `pyproject.toml` files that allow the package to be installed via pip rather than requiring explicitly adding the package to `PYTHONPATH`

This may be overkill, but I thought I would put the request in just in case it seems worthwhile to have. 